### PR TITLE
Infrastructure Setup and Terraform Configuration Fixes

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -9,7 +9,7 @@ terraform {
 
   backend "azurerm" {
     resource_group_name  = "cst8918-final-project-group-1"
-    storage_account_name = "cst8918tfstate"
+    storage_account_name = "cst8918tfstate2025"
     container_name       = "terraform-state"
     key                  = "dev/terraform.tfstate"
   }

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -9,7 +9,7 @@ terraform {
 
   backend "azurerm" {
     resource_group_name  = "cst8918-final-project-group-1"
-    storage_account_name = "cst8918tfstate"
+    storage_account_name = "cst8918tfstate2025"
     container_name       = "terraform-state"
     key                  = "prod/terraform.tfstate"
   }

--- a/environments/test/main.tf
+++ b/environments/test/main.tf
@@ -9,7 +9,7 @@ terraform {
 
   backend "azurerm" {
     resource_group_name  = "cst8918-final-project-group-1"
-    storage_account_name = "cst8918tfstate"
+    storage_account_name = "cst8918tfstate2025"
     container_name       = "terraform-state"
     key                  = "test/terraform.tfstate"
   }

--- a/modules/aks/main.tf
+++ b/modules/aks/main.tf
@@ -42,11 +42,7 @@ resource "azurerm_kubernetes_cluster" "main" {
     docker_bridge_cidr = "172.17.0.1/16"
   }
 
-  addon_profile {
-    azure_policy {
-      enabled = true
-    }
-  }
+  azure_policy_enabled = true
 
   tags = var.tags
 }

--- a/modules/weather-app/main.tf
+++ b/modules/weather-app/main.tf
@@ -30,7 +30,7 @@ resource "azurerm_redis_cache" "main" {
   capacity            = var.redis_capacity
   family              = "C"
   sku_name            = var.redis_sku
-  enable_non_ssl_port = false
+  non_ssl_port_enabled = false
   tags                = var.tags
 }
 


### PR DESCRIPTION
   ## Changes Made
   
   - ✅ Created Azure service principal for GitHub Actions
   - ✅ Configured GitHub Secrets (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID)
   - ✅ Created Azure backend infrastructure (Resource Group, Storage Account, Blob Container)
   - ✅ Updated Terraform backend configuration with new storage account name
   - ✅ Fixed deprecated Terraform configurations:
     - Replaced `addon_profile` with `azure_policy_enabled` in AKS module
     - Updated `enable_non_ssl_port` to `non_ssl_port_enabled` in Redis module
   - ✅ Verified Terraform plan works correctly for dev environment
   
   ## Infrastructure Components Ready
   
   - Resource Group: `cst8918-final-project-group-1`
   - Storage Account: `cst8918tfstate2025`
   - Blob Container: `terraform-state`
   - Terraform backend configured for all environments (dev, test, prod)
   
   ## Next Steps
   
   - [ ] Deploy infrastructure to dev environment
   - [ ] Test GitHub Actions workflows
   - [ ] Begin team collaboration on application development