### PR TITLE
fix: 移除Docker缓存配置以支持多架构构建

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -43,6 +43,4 @@ jobs:
           push: true
           tags: |
             ${{ secrets.ACR_LOGIN_SERVER }}/weather-app:${{ github.sha }}
-            ${{ secrets.ACR_LOGIN_SERVER }}/weather-app:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max 
+            ${{ secrets.ACR_LOGIN_SERVER }}/weather-app:latest 


### PR DESCRIPTION
## 修复内容

### 🔧 问题描述
GitHub Actions构建失败，错误信息：
`
ERROR: failed to build: Cache export is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
`

### 🛠️ 解决方案
- **移除Docker缓存配置**: 删除 cache-from 和 cache-to 配置
- **保持多架构支持**: 保留 platforms: linux/amd64,linux/arm64 配置
- **简化构建流程**: 确保GitHub Actions可以成功构建多架构镜像

### 📝 技术细节
- 更新 .github/workflows/build-app.yml
- 移除与多架构构建不兼容的缓存配置
- 保持镜像标签和推送配置不变

### ✅ 预期结果
- ✅ GitHub Actions构建成功
- ✅ 多架构镜像正确构建和推送
- ✅ 解决Docker缓存兼容性问题

### 🔄 测试建议
1. 合并后观察GitHub Actions构建日志
2. 确认多架构镜像成功推送到ACR
3. 验证部署到AKS集群成功