### PR TITLE
fix: 使用单架构构建以兼容GitHub Actions

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -39,7 +39,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./weather-app
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ secrets.ACR_LOGIN_SERVER }}/weather-app:${{ github.sha }}


### PR DESCRIPTION
## 修复内容

### 🔧 问题描述
GitHub Actions构建失败，错误信息：
`
ERROR: failed to build: Multi-platform build is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
`

### 🛠️ 解决方案
- **移除多架构配置**: 删除 platforms: linux/amd64,linux/arm64 配置
- **使用默认单架构**: 让Docker使用默认架构构建
- **保持基本功能**: 确保镜像可以正常构建和推送

### 📝 技术细节
- 更新 .github/workflows/build-app.yml
- 移除 platforms 配置
- 保持镜像标签和推送配置不变

### ✅ 预期结果
- ✅ GitHub Actions构建成功
- ✅ 镜像正确构建和推送到ACR
- ✅ 解决GitHub Actions Docker环境限制

### 🔄 后续优化
如果需要多架构支持，可以考虑：
1. 使用GitHub Actions的自托管运行器
2. 配置专门的Docker构建环境
3. 使用Azure Container Registry的多架构构建功能

### 🧪 测试建议
1. 合并后观察GitHub Actions构建日志
2. 确认镜像成功推送到ACR
3. 验证部署到AKS集群成功