### PR TITLE
fix: 使用硬编码ACR名称以解决参数传递问题

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -29,11 +29,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Azure Container Registry
-        uses: azure/docker-login@v1
-        with:
-          login-server: ${{ secrets.ACR_LOGIN_SERVER }}
-          username: ${{ secrets.ACR_USERNAME }}
-          password: ${{ secrets.ACR_PASSWORD }}
+        run: |
+          az acr login --name ${{ secrets.ACR_NAME }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Log in to Azure Container Registry
         run: |
-          az acr login --name ${{ secrets.ACR_NAME }}
+          az acr login --name cst8918acr
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
修复az acr login命令的参数传递问题，使用硬编码的ACR名称cst8918acr替代secret变量